### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.28.0
 oauthlib~=3.2.0
-
+ascii_magic==1.6


### PR DESCRIPTION
Module doesn't function without specifically ascii_magic 1.6

Fixes #2 